### PR TITLE
Changed typos on Level 3 Step 1 & 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,28 +82,28 @@ Don't worry about being pixel perfect, and don't worry if your code doesn't matc
 * Locate the element with the class of `main-top-section`.
   * Add a background color of `#F2EFE5`.
 * Locate the element with the class of `menu-icon`.
-  * Link the src path to `level-3/img/icons/MENU`.
+  * Link the src path to `/img/icons/MENU.png`.
 * Locate the element with the class of `logo-icon`.
-  * Link the src path to `level-3/img/icons/dev-shop`.
+  * Link the src path to `/img/icons/dev-shop.png`.
 * Locate the element with the class of `sign-in`.
-  * Link the src path to `level-3/img/icons/Sign_In`.
+  * Link the src path to `/img/icons/Sign_In.png`.
 * Locate the element with the class of `shop-icon`.
-  * Link the src path to `level-3/img/icons/Shop_Deals`.
+  * Link the src path to `/img/icons/Shop_Deals.png`.
 
 ## Step 2
 
 * Locate the element with the class of `item-image` and alt of `tops`.
-  * Link the src path to `level-3/img/Tops.png`.
+  * Link the src path to `/img/Tops.png`.
 * Locate the element with the class of `item-image` and alt of `bottoms`.
-  * Link the src path to `level-3/img/bottoms.png`.
+  * Link the src path to `/img/bottoms.png`.
 * Locate the element with the class of `item-image` and alt of `accessories`.
-  * Link the src path to `level-3/img/accessories.png`.
+  * Link the src path to `/img/accessories.png`.
 * Locate the element with the class of `item-image` and alt of `collection`.
-  * Link the src path to `level-3/img/collection.png`.
+  * Link the src path to `/img/collection.png`.
 * Locate the element with the class of `item-image` and alt of `kicks`.
-  * Link the src path to `level-3/img/kicks.png`.
+  * Link the src path to `/img/kicks.png`.
 * Locate the element with the class of `item-image` and alt of `hats`.
-  * Link the src path to `level-3/img/hats.png`
+  * Link the src path to `/img/hats.png`
 
 ## Contributions
 


### PR DESCRIPTION
There were typos on Level 3 on Step 1 and Step 2 README.md file.

**Step 1**
When asked to link the src path, the src path name was /level-3/img/icons/**FILENAME**. Since the code is run in the level-3 folder, using the given path name would result in an error.

Also the file extension was not included in the filename.

**Step 2**
When asked to link the src path, the src path name was /level-3/img/icons/**FILENAME**.png. Since the code is run in the level-3 folder using the given path name would result in an error.
